### PR TITLE
Add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ validity-sensors-tools --help
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/validity-sensors-tools)
 
+#### Installing from AUR on Arch Linux
+
+Install [validity-sensors-tools-git<sup>[AUR]</sup>](https://aur.archlinux.org/packages/validity-sensors-tools-git/).
+
+You can run it as `validity-sensors-tools`:
+
+```bash
+sudo validity-sensors-tools -t led-dance
+```
+
 ---
 
 ### Getting the firmware


### PR DESCRIPTION
AUR package is up :) https://aur.archlinux.org/packages/validity-sensors-tools-git

I had to package `fastecdsa` v1.7.4 since patching `proto9x` to use the latest version was taking more time than I was willing to spend, ideally it should be fixed.

Also, since the custom repo for `pycrypto` only adds one commit that simply changes `time.clock` to `time.process_time` due to deprecation, I simply monkey-patched the `time` module in `tls.py` during build-time and asked `python-pycrypto`'s maintainer to merge the patch, eventually.